### PR TITLE
replace fzf#vim#grep to ignore filename matches

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -151,6 +151,9 @@ command! FZFMru call fzf#run({
 \  'options': '-m -x +s',
 \  'down':    '40%'})
 nnoremap fr :FZFMru<CR>
+command! -bang -nargs=* Rg call fzf#vim#grep(
+\  'rg --column --line-number --no-heading --color=always --smart-case '.shellescape(<q-args>), 1,
+\  fzf#vim#with_preview({'options': '--delimiter : --nth 4..'}, 'up:50%'), <bang>0)
 
 " ale
 let g:ale_linters = {


### PR DESCRIPTION
- references:
    - https://github.com/junegunn/fzf.vim
    - https://stackoverflow.com/questions/59885329/how-to-exclude-file-name-from-fzf-filtering-after-ripgrep-search-results